### PR TITLE
Add new allowed host

### DIFF
--- a/live_data_server/live_data_server/settings.py
+++ b/live_data_server/live_data_server/settings.py
@@ -28,7 +28,7 @@ DEBUG = bool(os.environ.get("APP_DEBUG", False))
 #SESSION_COOKIE_SECURE = True
 CSRF_TRUSTED_ORIGINS = ['.ornl.gov', '.sns.gov', 'localhost', '127.0.0.1']
  
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'testfixture02-test.ornl.gov', 'livedata.sns.gov']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'testfixture02-test.ornl.gov', 'livedata.sns.gov', 'scse-livedata-prod1.sns.gov']
 
 
 # Application definition


### PR DESCRIPTION
# Short description of the changes:
The Live Data Server host name is changing as part of the migration from RHEL7 to RHEL9. Add the new host to allowed hosts.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# References
[Story 4767: [LiveDataServer] Deploy containerized Live Data Server and test with WebMon test environment](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4767)
