### PR TITLE
Fix minor issues with GET request

### DIFF
--- a/live_data_server/plots/view_util.py
+++ b/live_data_server/plots/view_util.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from plots.models import Instrument, DataRun, PlotData
 import hashlib
 
+
 def generate_key(instrument, run_id):
     """
         Generate a secret key for a run on a given instrument
@@ -23,8 +24,9 @@ def generate_key(instrument, run_id):
         return None
     else:
         h = hashlib.sha1()
-        h.update("%s%s%s" % (instrument.upper(), secret_key, run_id))
+        h.update(("%s%s%s" % (instrument.upper(), secret_key, run_id)).encode("utf-8"))
         return h.hexdigest()
+
 
 def check_key(fn):
     """
@@ -46,9 +48,10 @@ def check_key(fn):
                 return fn(request, instrument, run_id)
             return HttpResponse(status=401)
         except:
-            logging.error("[%s]: %s", request.path, sys.exc_value)
+            logging.error("[%s]: %s" % (request.path, sys.exc_info()[1]))
             return HttpResponse(status=500)
     return request_processor
+
 
 def get_or_create_run(instrument, run_id, create=True):
     """
@@ -99,6 +102,7 @@ def get_plot_data(instrument, run_id, data_type=None):
             return plot
     return None
 
+
 def store_user_data(user, data_id, data, data_type):
     """
         Store plot data and associate it to a user identifier (a name, not
@@ -141,6 +145,7 @@ def store_user_data(user, data_id, data, data_type):
     plot_data.data_type = data_type
     plot_data.timestamp = timezone.now()
     plot_data.save()
+
 
 def store_plot_data(instrument, run_id, data, data_type):
     """

--- a/live_data_server/plots/views.py
+++ b/live_data_server/plots/views.py
@@ -37,8 +37,8 @@ def check_credentials(fn):
         if request.user.is_authenticated:
             return fn(request, *args, **kws)
         if request.method == 'POST':
-            username = request.POST["username"]
-            password = request.POST["password"]
+            username = request.POST.get("username")
+            password = request.POST.get("password")
             request_user = authenticate(username=username, password=password)
             if request_user is not None and not request_user.is_anonymous:
                 login(request, request_user)

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -1,12 +1,11 @@
-from __future__ import print_function
-
 # standard imports
+import hashlib
 import json
 import os
 import requests
 
 
-def test_post_get(data_server):
+def test_post_request(data_server):
     http_ok = requests.status_codes.codes["OK"]
     username = os.environ.get("DJANGO_SUPERUSER_USERNAME")
     monitor_user = {"username": username,
@@ -43,3 +42,56 @@ def test_post_get(data_server):
     assert http_request.status_code == http_ok
 
 
+def test_get_request(data_server):
+    """Test GET request for HTML data like from monitor.sns.gov"""
+    instrument = "REF_M"
+    run_number = 12346
+    http_ok = requests.status_codes.codes["OK"]
+    http_unauthorized = requests.status_codes.codes["unauthorized"]
+
+    # upload the run data using POST (authenticate with username and password)
+    username = os.environ.get("DJANGO_SUPERUSER_USERNAME")
+    monitor_user = {"username": username,
+                    "password": os.environ.get("DJANGO_SUPERUSER_PASSWORD")}
+    # load html plot as autoreduce service
+    file_name = 'reflectivity.html'
+    files = {"file": open(data_server.path_to(file_name)).read()}
+    monitor_user["data_id"] = file_name
+
+    http_request = requests.post(f"http://127.0.0.1:80/plots/{instrument}/{run_number}/upload_plot_data/",
+                                 data=monitor_user, files=files, verify=True)
+    assert http_request.status_code == http_ok
+
+    base_url = f"http://127.0.0.1:80/plots/{instrument}/{run_number}/update/html/"
+
+    # test GET request - authenticate with secret key
+    url = f"{base_url}?key={_generate_key(instrument, run_number)}"
+    http_request = requests.get(url)
+    assert http_request.status_code == http_ok
+
+    # test GET request - no key
+    # TODO: this should return 401 unauthorized
+    url = base_url
+    http_request = requests.get(url)
+    assert http_request.status_code == http_ok
+
+    # test GET request - wrong key
+    url = f"{base_url}?key=WRONG-KEY"
+    http_request = requests.get(url)
+    assert http_request.status_code == http_unauthorized
+
+
+def _generate_key(instrument, run_id):
+    """
+        Generate a secret key for a run on a given instrument
+        Used to simulate clients sending GET-requests using a secret key
+        @param instrument: instrument name
+        @param run_id: run number
+    """
+    secret_key = os.environ.get("LIVE_PLOT_SECRET_KEY")
+    if len(secret_key) == 0:
+        return None
+    else:
+        h = hashlib.sha1()
+        h.update(("%s%s%s" % (instrument.upper(), secret_key, run_id)).encode("utf-8"))
+        return h.hexdigest()


### PR DESCRIPTION
# Short description of the changes:
Fix minor issues found in testing Live Data Server with the WebMon test environment. Add unit test for GET request.

This is the logged error in the Live Data Server container on `scse-livedata-prod1`:
```
Internal Server Error: /plots/hb2c/1322509/update/html/
Traceback (most recent call last):
  File "/var/www/livedata/app/plots/view_util.py", line 42, in request_processor
    server_key = generate_key(instrument, run_id)
  File "/var/www/livedata/app/plots/view_util.py", line 26, in generate_key
    h.update("%s%s%s" % (instrument.upper(), secret_key, run_id))
TypeError: Unicode-objects must be encoded before hashing

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/envs/livedata/lib/python3.6/site-packages/django/core/handlers/exception.py", line 35, in inner
    response = get_response(request)
  File "/opt/conda/envs/livedata/lib/python3.6/site-packages/django/core/handlers/base.py", line 128, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/opt/conda/envs/livedata/lib/python3.6/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/var/www/livedata/app/plots/view_util.py", line 49, in request_processor
    logging.error("[%s]: %s", request.path, sys.exc_value)
AttributeError: module 'sys' has no attribute 'exc_value'
```

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [x] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
Define environment variables (set the hidden values to any strings you like):
```
export DATABASE_NAME=***
export DATABASE_USER=***
export DATABASE_PASS=***
export DATABASE_HOST=db  # name of the db docker service
export DATABASE_PORT=5432
export LIVE_PLOT_SECRET_KEY=***
export DJANGO_SUPERUSER_USERNAME=$DATABASE_USER
export DJANGO_SUPERUSER_PASSWORD=$DATABASE_PASS
```
Start the containers:
```
make local/docker/up
```
and when the containers are up run the unit test:
```
pytest tests
```

# References
[Story 4767: [LiveDataServer] Deploy containerized Live Data Server and test with WebMon test environment](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4767)
story to fix authentication issues later: [Story 4972: LiveDataServer Modernization](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4972)
