### PR TITLE
Decode plot data from bytestring to utf-8 before storing in database

### DIFF
--- a/live_data_server/plots/models.py
+++ b/live_data_server/plots/models.py
@@ -80,7 +80,7 @@ class PlotData(models.Model):
             Inspect the data to guess what type it is.
             @param data: block of text to store
         """
-        if data.startswith(b'<div'):
+        if data.startswith('<div'):
             return DATA_TYPES['html']
         return DATA_TYPES['json']
 

--- a/live_data_server/plots/views.py
+++ b/live_data_server/plots/views.py
@@ -114,7 +114,7 @@ def _store(request, instrument, run_id=None, as_user=False):
         @param as_user: if True, we will store as user data
     """
     if request.user.is_authenticated and 'file' in request.FILES:
-        raw_data = request.FILES['file'].read()
+        raw_data = request.FILES['file'].read().decode('utf-8')
         data_type_default = PlotData.get_data_type_from_data(raw_data)
         data_type = request.POST.get('data_type', default=data_type_default)
         if as_user:

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -68,6 +68,7 @@ def test_get_request(data_server):
     url = f"{base_url}?key={_generate_key(instrument, run_number)}"
     http_request = requests.get(url)
     assert http_request.status_code == http_ok
+    assert http_request.text == files["file"]
 
     # test GET request - no key
     # TODO: this should return 401 unauthorized


### PR DESCRIPTION
# Short description of the changes:

When storing plot data from a request to Live Data Server, we need to decode the plot data from bytestring to UTF-8 first.

# Long description of the changes:

After deploying the latest version of Live Data Server, new plots that are published to Live Data Server appear on monitor.sns.gov with '\n' instead of linebreaks:

![Screenshot from 2024-06-04 10-34-24](https://github.com/neutrons/live_data_server/assets/6989921/e4d54d40-9a93-48de-8267-9327e3a0564c)



This seems related to a Django 2.0 change in how bytestrings are handled: https://docs.djangoproject.com/en/5.0/releases/2.0/#removed-support-for-bytestrings-in-some-places

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
Define environment variables (set the hidden values to any strings you like):
```
export DATABASE_NAME=***
export DATABASE_USER=***
export DATABASE_PASS=***
export DATABASE_HOST=db  # name of the db docker service
export DATABASE_PORT=5432
export LIVE_PLOT_SECRET_KEY=***
export DJANGO_SUPERUSER_USERNAME=$DATABASE_USER
export DJANGO_SUPERUSER_PASSWORD=$DATABASE_PASS
```
Start the containers:
```
make local/docker/up
```
and when the containers are up run the unit test:
```
pytest tests
```

# References
[Defect 5534: Live Data Server plot html string encoding issue](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5534)