### PR TITLE
Remove key check bypass and add ability to pass key in Authorization header

### DIFF
--- a/src/live_data_server/plots/view_util.py
+++ b/src/live_data_server/plots/view_util.py
@@ -45,9 +45,7 @@ def check_key(fn):
         try:
             client_key = request.GET.get("key", None)
             server_key = generate_key(instrument, run_id)
-            # Temporary bypass during testing
-            # Remove client_key is None condition when we deploy
-            if client_key is None or server_key is None or client_key == server_key:
+            if server_key is None or client_key == server_key:
                 return fn(request, instrument, run_id)
             return HttpResponse(status=401)
         except:  # noqa: E722

--- a/src/live_data_server/plots/view_util.py
+++ b/src/live_data_server/plots/view_util.py
@@ -24,10 +24,8 @@ def generate_key(instrument, run_id):
     secret_key = settings.LIVE_PLOT_SECRET_KEY
     if len(secret_key) == 0:
         return None
-    else:
-        h = hashlib.sha1()
-        h.update(("%s%s%s" % (instrument.upper(), secret_key, run_id)).encode("utf-8"))
-        return h.hexdigest()
+
+    return hashlib.sha1(f"{instrument.upper()}{secret_key}{run_id}".encode("utf-8")).hexdigest()
 
 
 def check_key(fn):
@@ -43,9 +41,18 @@ def check_key(fn):
         Decorator function
         """
         try:
-            client_key = request.GET.get("key", None)
             server_key = generate_key(instrument, run_id)
-            if server_key is None or client_key == server_key:
+            if server_key is None:
+                return fn(request, instrument, run_id)
+
+            client_key = request.META.get("HTTP_AUTHORIZATION")
+
+            # getting the client_key from request.GET.get("key") should be
+            # removed after WebMon/WebRef supports Authorization request header
+            if client_key is None:
+                client_key = request.GET.get("key")
+
+            if client_key == server_key:
                 return fn(request, instrument, run_id)
             return HttpResponse(status=401)
         except:  # noqa: E722

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -113,6 +113,13 @@ class TestLiveDataServer:
         http_request = requests.get(url)
         assert http_request.status_code == HTTP_UNAUTHORIZED
 
+        # test GET request - wrong key
+        http_request = requests.get(
+            base_url,
+            headers={"Authorization": "WRONG-KEY"},
+        )
+        assert http_request.status_code == HTTP_UNAUTHORIZED
+
     def test_upload_plot_data_json(self):
         # test that when you upload json you can get back the same stuff
         instrument = "instrument0"
@@ -145,7 +152,8 @@ class TestLiveDataServer:
 
         # now get the data as json
         response = requests.get(
-            f"{TEST_URL}/plots/{instrument}/{run_number}/update/json/?key={_generate_key(instrument, run_number)}"
+            f"{TEST_URL}/plots/{instrument}/{run_number}/update/json/",
+            headers={"Authorization": _generate_key(instrument, run_number)},
         )
         assert response.status_code == HTTP_OK
         assert response.headers["Content-Type"] == "application/json"
@@ -153,7 +161,8 @@ class TestLiveDataServer:
 
         # now try getting it as html, should fail
         response = requests.get(
-            f"{TEST_URL}/plots/{instrument}/{run_number}/update/html/?key={_generate_key(instrument, run_number)}"
+            f"{TEST_URL}/plots/{instrument}/{run_number}/update/html/",
+            headers={"Authorization": _generate_key(instrument, run_number)},
         )
         assert response.status_code == HTTP_NOT_FOUND
         assert response.text == "No data available for instrument0 123"
@@ -234,9 +243,7 @@ def _generate_key(instrument, run_id):
     @param run_id: run number
     """
     secret_key = os.environ.get("LIVE_PLOT_SECRET_KEY")
-    if len(secret_key) == 0:
+    if secret_key is None or len(secret_key) == 0:
         return None
-    else:
-        h = hashlib.sha1()
-        h.update(("%s%s%s" % (instrument.upper(), secret_key, run_id)).encode("utf-8"))
-        return h.hexdigest()
+
+    return hashlib.sha1(f"{instrument.upper()}{secret_key}{run_id}".encode("utf-8")).hexdigest()

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -104,10 +104,9 @@ class TestLiveDataServer:
         assert http_request.text == "No data available for REF_M 12346"
 
         # test GET request - no key
-        # TODO: this should return 401 unauthorized
         url = base_url
         http_request = requests.get(url)
-        assert http_request.status_code == HTTP_OK
+        assert http_request.status_code == HTTP_UNAUTHORIZED
 
         # test GET request - wrong key
         url = f"{base_url}?key=WRONG-KEY"


### PR DESCRIPTION
This will first check the secret key in the HTTP Authorization request header before falling back to checking for the query string for the key. Once WebMon and WebRef support the new method the check for `key` in the query string should be removed.

Once you run the tests you can test manually test this with `curl`, _e.g._ the following two command should return the same

```
curl -k 127.0.0.1/plots/instrument0/123/update/json/?key=8c43bacc1c565d1febf2bbbb99319b0a7513f4a7
```

```
curl -k 127.0.0.1/plots/instrument0/123/update/json/ --header "Authorization: 8c43bacc1c565d1febf2bbbb99319b0a7513f4a7"
```

Half the tests were updated to use the new Authorization header approach and the other half use the old method.

Ref: [5923: [LiveDataServer] Change API key handling](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/5923)

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
