### PR TITLE
Remove ability to send key via query string

### DIFF
--- a/src/live_data_server/plots/view_util.py
+++ b/src/live_data_server/plots/view_util.py
@@ -47,11 +47,6 @@ def check_key(fn):
 
             client_key = request.META.get("HTTP_AUTHORIZATION")
 
-            # getting the client_key from request.GET.get("key") should be
-            # removed after WebMon/WebRef supports Authorization request header
-            if client_key is None:
-                client_key = request.GET.get("key")
-
             if client_key == server_key:
                 return fn(request, instrument, run_id)
             return HttpResponse(status=401)

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -88,34 +88,31 @@ class TestLiveDataServer:
         )
         assert http_request.status_code == HTTP_OK
 
-        base_url = f"{TEST_URL}/plots/{instrument}/{run_number}/update/html/"
+        url = f"{TEST_URL}/plots/{instrument}/{run_number}/update/html/"
 
         # test GET request - authenticate with secret key
-        url = f"{base_url}?key={_generate_key(instrument, run_number)}"
-        http_request = requests.get(url)
+        http_request = requests.get(
+            url,
+            headers={"Authorization": _generate_key(instrument, run_number)},
+        )
         assert http_request.status_code == HTTP_OK
         assert http_request.text == files["file"]
 
         # test that getting the json should return not found
         http_request = requests.get(
-            f"{TEST_URL}/plots/{instrument}/{run_number}/update/json/?key={_generate_key(instrument, run_number)}"
+            f"{TEST_URL}/plots/{instrument}/{run_number}/update/json/",
+            headers={"Authorization": _generate_key(instrument, run_number)},
         )
         assert http_request.status_code == HTTP_NOT_FOUND
         assert http_request.text == "No data available for REF_M 12346"
 
         # test GET request - no key
-        url = base_url
-        http_request = requests.get(url)
-        assert http_request.status_code == HTTP_UNAUTHORIZED
-
-        # test GET request - wrong key
-        url = f"{base_url}?key=WRONG-KEY"
         http_request = requests.get(url)
         assert http_request.status_code == HTTP_UNAUTHORIZED
 
         # test GET request - wrong key
         http_request = requests.get(
-            base_url,
+            url,
             headers={"Authorization": "WRONG-KEY"},
         )
         assert http_request.status_code == HTTP_UNAUTHORIZED


### PR DESCRIPTION
Once WebMon and WebRef have been updated to use the new method of sending the secret key we can remove the old method.

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
