### PR TITLE
Remove obsolete JSON format support from Live Data Server

### DIFF
--- a/src/apps/plots/models.py
+++ b/src/apps/plots/models.py
@@ -57,16 +57,16 @@ class DataRun(models.Model):
 
 
 class PlotData(models.Model):
-    """Table of plot data. This data can either be json or html"""
+    """Table of plot data containing HTML content"""
 
     ## DataRun this run status belongs to
     data_run = models.ForeignKey(DataRun, on_delete=models.deletion.CASCADE)
     ## Data type:
     ##    type = 100 for live data, 0 static reduced.
-    ##    type += 1 for HTML, 0 for JSON
+    ##    type += 1 for HTML
     data_type = models.IntegerField()
 
-    ## JSON/HTML data
+    ## HTML data
     data = models.TextField()
 
     timestamp = models.DateTimeField("Timestamp")

--- a/src/apps/plots/models.py
+++ b/src/apps/plots/models.py
@@ -12,8 +12,8 @@ from django.utils import timezone
 
 from config.instruments import Instruments
 
-DATA_TYPES = {"json": 0, "html": 1, "div": 1}
-DATA_TYPE_INFO = {0: {"name": "json"}, 1: {"name": "html"}}
+DATA_TYPES = {"html": 1}
+DATA_TYPE_INFO = {1: {"name": "html"}}
 
 
 class Instrument(models.Model):
@@ -85,18 +85,3 @@ class PlotData(models.Model):
         except ValueError:
             logging.error("Could not verify data type: %s", sys.exc_value)
             return False
-
-    @classmethod
-    def get_data_type_from_data(cls, data):
-        """Inspect the data to guess what type it is.
-
-        @param data: block of text to store
-        """
-        if data.startswith("<div"):
-            return DATA_TYPES["html"]
-        return DATA_TYPES["json"]
-
-    @classmethod
-    def get_data_type_from_string(cls, type_string):
-        """Returns the correct data type ID for a given string representation"""
-        return DATA_TYPES.get(type_string, DATA_TYPES["json"])

--- a/src/apps/plots/urls.py
+++ b/src/apps/plots/urls.py
@@ -9,11 +9,8 @@ from . import views
 app_name = "plots"
 
 urlpatterns = [
-    re_path(r"^(?P<instrument>[\w]+)/(?P<run_id>\d+)/update/json/$", views.update_as_json, name="update_as_json"),
     re_path(r"^(?P<instrument>[\w]+)/(?P<run_id>\d+)/update/html/$", views.update_as_html, name="update_as_html"),
     re_path(
         r"^(?P<instrument>[\w]+)/(?P<run_id>\d+)/upload_plot_data/$", views.upload_plot_data, name="upload_plot_data"
     ),
-    re_path(r"^(?P<user>[\w]+)/upload_user_data/$", views.upload_user_data, name="upload_user_data"),
-    re_path(r"^(?P<instrument>[\w]+)/list/$", views.get_data_list, name="get_data_list"),
 ]

--- a/src/apps/plots/view_util.py
+++ b/src/apps/plots/view_util.py
@@ -104,7 +104,7 @@ def get_or_create_run(
     return run_obj
 
 
-def get_plot_data(instrument, run_id, data_type=None):
+def get_plot_data(instrument, run_id):
     """
     Get plot data for requested instrument and run number
     @param instrument: instrument name
@@ -112,58 +112,9 @@ def get_plot_data(instrument, run_id, data_type=None):
     """
     run_obj = get_or_create_run(instrument, run_id, create=False)
     plot_data_list = PlotData.objects.filter(data_run=run_obj)
-    for plot in plot_data_list:
-        if data_type is not None:
-            if plot.is_data_type_valid(data_type):
-                return plot
-        else:
-            return plot
+    if len(plot_data_list) > 0:
+        return plot_data_list[0]
     return None
-
-
-def store_user_data(user, data_id, data, data_type, expiration_date: Optional[datetime] = None):
-    """
-    Store plot data and associate it to a user identifier
-    (a name, not an actual user since users don't log in to this system).
-    """
-    # Get or create the instrument
-    instrument_list = Instrument.objects.filter(name=user.lower())
-    if len(instrument_list) > 0:
-        instrument_obj = instrument_list[0]
-    else:
-        instrument_obj = Instrument()
-        instrument_obj.name = user.lower()
-        instrument_obj.save()
-
-    run_list = DataRun.objects.filter(instrument=instrument_obj, run_id=data_id)
-    if len(run_list) > 0:
-        run_obj = run_list.latest("created_on")
-    else:
-        run_obj = DataRun()
-        run_obj.instrument = instrument_obj
-        run_obj.run_number = 0
-        run_obj.run_id = data_id
-        run_obj.expiration_date = expiration_date
-        # Save run object to generate id (primary key)
-        run_obj.save()
-        # User data has no run number, use the unique id as the run number
-        # so that the user can retrieve the data like normal instrument data
-        run_obj.run_number = run_obj.id
-        run_obj.save()
-
-    # Look for a data file and treat it differently
-    data_entries = PlotData.objects.filter(data_run=run_obj)
-    if len(data_entries) > 0:
-        plot_data = data_entries[0]
-    else:
-        # No entry was found, create one
-        plot_data = PlotData()
-        plot_data.data_run = run_obj
-
-    plot_data.data = data
-    plot_data.data_type = data_type
-    plot_data.timestamp = timezone.now()
-    plot_data.save()
 
 
 def store_plot_data(instrument, run_id, data, data_type, expiration_date: Optional[datetime] = None):

--- a/src/apps/plots/views.py
+++ b/src/apps/plots/views.py
@@ -2,19 +2,17 @@
 Definition of views
 """
 
-import json
 import logging
 from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth import authenticate, login
-from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
-from django.shortcuts import get_object_or_404
-from django.utils import dateformat, timezone
+from django.http import HttpResponse, HttpResponseNotFound
+from django.utils import timezone
 from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_exempt
 
-from apps.plots.models import DataRun, Instrument, PlotData
+from apps.plots.models import DATA_TYPES, DataRun, Instrument, PlotData
 
 from . import view_util
 
@@ -47,34 +45,13 @@ def check_credentials(fn):
 
 @view_util.check_key
 @cache_page(15)
-def update_as_json(request, instrument, run_id):  # noqa: ARG001
-    """
-    Ajax call to get JSON data
-    @param instrument: instrument name
-    @param run_id: run number
-    """
-    data_type = PlotData.get_data_type_from_string("json")
-    plot_data = view_util.get_plot_data(instrument, run_id, data_type=data_type)
-
-    if plot_data is None:
-        error_msg = f"No data available for {instrument} {run_id}"
-        logging.error(error_msg)
-        return HttpResponseNotFound(error_msg)
-
-    json_data = json.loads(plot_data.data)
-    return JsonResponse(json_data, safe=False)
-
-
-@view_util.check_key
-@cache_page(15)
 def update_as_html(request, instrument, run_id):  # noqa: ARG001
     """
     Ajax call to get plot data as an html <div>
     @param instrument: instrument name
     @param run_id: run number
     """
-    data_type = PlotData.get_data_type_from_string("html")
-    plot_data = view_util.get_plot_data(instrument, run_id, data_type=data_type)
+    plot_data = view_util.get_plot_data(instrument, run_id)
 
     if plot_data is None:
         error_msg = f"No data available for {instrument} {run_id}"
@@ -87,29 +64,20 @@ def update_as_html(request, instrument, run_id):  # noqa: ARG001
 
 
 @check_credentials
-def _store(request, instrument, run_id=None, as_user=False):
+def _store(request, instrument, run_id):
     """
     Store plot data
-    @param instrument: instrument name or user name
+    @param instrument: instrument name
     @param run_id: run number
-    @param as_user: if True, we will store as user data
     """
     if "file" in request.FILES:
         raw_data = request.FILES["file"].read().decode("utf-8")
-        data_type_default = PlotData.get_data_type_from_data(raw_data)
-        data_type = request.POST.get("data_type", default=data_type_default)
+        data_type = DATA_TYPES["html"]  # Always HTML now
         expiration_date = request.POST.get(
             "expiration_date",
-            default=timezone.datetime(2100, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-            if as_user
-            else timezone.now() + timedelta(days=settings.LIVE_PLOT_EXPIRATION_TIME),
+            default=timezone.now() + timedelta(days=settings.LIVE_PLOT_EXPIRATION_TIME),
         )
-
-        if as_user:
-            data_id = request.POST.get("data_id", default="")
-            view_util.store_user_data(instrument, data_id, raw_data, data_type, expiration_date)
-        else:
-            view_util.store_plot_data(instrument, run_id, raw_data, data_type, expiration_date)
+        view_util.store_plot_data(instrument, run_id, raw_data, data_type, expiration_date)
     else:
         return HttpResponse(status=400)
 
@@ -123,41 +91,4 @@ def upload_plot_data(request, instrument, run_id):
     @param instrument: instrument name
     @param run_id: run number
     """
-    return _store(request, instrument, run_id, as_user=False)
-
-
-@csrf_exempt
-def upload_user_data(request, user):
-    """
-    Upload plot data
-    @param user: user identifier to use
-    """
-    return _store(request, user, as_user=True)
-
-
-@csrf_exempt
-@check_credentials
-def get_data_list(request, instrument):
-    """
-    Get a list of user data
-    """
-    instrument_object = get_object_or_404(Instrument, name=instrument.lower())
-    data_list = []
-    get_extra = request.POST.get("extra", default=False)
-    for item in DataRun.objects.filter(instrument=instrument_object):
-        timestamp_local = timezone.localtime(item.created_on)
-        timestamp_formatted = dateformat.DateFormat(timestamp_local).format(settings.DATETIME_FORMAT)
-        data = dict(
-            id=item.id,
-            run_number=str(item.run_number),
-            run_id=item.run_id,
-            timestamp=item.created_on.isoformat(),
-            created_on=timestamp_formatted,
-        )
-        if get_extra:
-            expiration_local = timezone.localtime(item.expiration_date)
-            expiration_formatted = dateformat.DateFormat(expiration_local).format(settings.DATETIME_FORMAT)
-            data["expiration_date"] = expiration_formatted
-            data["expired"] = True if expiration_local < timezone.now() else False
-        data_list.append(data)
-    return JsonResponse(data_list, safe=False)
+    return _store(request, instrument, run_id)

--- a/src/apps/plots/views.py
+++ b/src/apps/plots/views.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_exempt
 
-from apps.plots.models import DATA_TYPES, DataRun, Instrument, PlotData
+from apps.plots.models import DATA_TYPES
 
 from . import view_util
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import sys
 
@@ -18,6 +19,27 @@ def data_server():
         _directory = os.path.join(os.path.dirname(this_module_path), "data")
 
         @property
+        def directory(self):
+            return self._directory
+
+        def path_to(self, filename):
+            return os.path.join(self._directory, filename)
+
+    return _DataServe()
+
+
+def generate_key(instrument, run_id):
+    """
+    Generate a secret key for a run on a given instrument
+    Used to simulate clients sending GET-requests using a secret key
+    @param instrument: instrument name
+    @param run_id: run number
+    """
+    secret_key = os.environ.get("LIVE_PLOT_SECRET_KEY")
+    if secret_key is None or len(secret_key) == 0:
+        return None
+
+    return hashlib.sha1(f"{instrument.upper()}{secret_key}{run_id}".encode("utf-8")).hexdigest()
         def directory(self):
             """Directory where to find the data files"""
             return self._directory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,10 +20,15 @@ def data_server():
 
         @property
         def directory(self):
+            """Directory where to find the data files"""
             return self._directory
 
-        def path_to(self, filename):
-            return os.path.join(self._directory, filename)
+        def path_to(self, basename):
+            """Absolute path to a data file"""
+            file_path = os.path.join(self._directory, basename)
+            if not os.path.isfile(file_path):
+                raise IOError(f"File {basename} not found in data directory {self._directory}")
+            return file_path
 
     return _DataServe()
 
@@ -40,15 +45,3 @@ def generate_key(instrument, run_id):
         return None
 
     return hashlib.sha1(f"{instrument.upper()}{secret_key}{run_id}".encode("utf-8")).hexdigest()
-        def directory(self):
-            """Directory where to find the data files"""
-            return self._directory
-
-        def path_to(self, basename):
-            """Absolute path to a data file"""
-            file_path = os.path.join(self._directory, basename)
-            if not os.path.isfile(file_path):
-                raise IOError(f"File {basename} not found in data directory {self._directory}")
-            return file_path
-
-    return _DataServe()

--- a/tests/test_expiration.py
+++ b/tests/test_expiration.py
@@ -1,10 +1,11 @@
-import hashlib
 import os
 import subprocess
 from datetime import datetime, timedelta, timezone
 
 import psycopg
 import requests
+
+from tests.conftest import generate_key
 
 TEST_URL = "http://127.0.0.1:8000"
 HTTP_OK = requests.status_codes.codes["OK"]
@@ -72,13 +73,15 @@ class TestLiveDataServer:
         # But we can verify they're retrievable
         response1 = requests.get(
             f"{TEST_URL}/plots/{instrument}/12345/update/html/",
-            headers={"Authorization": _generate_key(instrument, 12345)},
+            headers={"Authorization": generate_key(instrument, 12345)},
+            timeout=10,
         )
         assert response1.status_code == HTTP_OK
 
         response2 = requests.get(
             f"{TEST_URL}/plots/{instrument}/12346/update/html/",
-            headers={"Authorization": _generate_key(instrument, 12346)},
+            headers={"Authorization": generate_key(instrument, 12346)},
+            timeout=10,
         )
         assert response2.status_code == HTTP_OK
 
@@ -111,17 +114,3 @@ class TestLiveDataServer:
         results = cur.fetchall()
         print(f"Plots after purge: {len(results)}")
         assert len(results) == 1  # Only one non-expired run should remain
-
-
-def _generate_key(instrument, run_id):
-    """
-    Generate a secret key for a run on a given instrument
-    Used to simulate clients sending GET-requests using a secret key
-    @param instrument: instrument name
-    @param run_id: run number
-    """
-    secret_key = os.environ.get("LIVE_PLOT_SECRET_KEY")
-    if secret_key is None or len(secret_key) == 0:
-        return None
-
-    return hashlib.sha1(f"{instrument.upper()}{secret_key}{run_id}".encode("utf-8")).hexdigest()

--- a/tests/test_expiration.py
+++ b/tests/test_expiration.py
@@ -1,4 +1,4 @@
-import json
+import hashlib
 import os
 import subprocess
 from datetime import datetime, timedelta, timezone
@@ -68,52 +68,19 @@ class TestLiveDataServer:
         )
         assert request.status_code == HTTP_OK
 
-        request = requests.post(
-            f"{TEST_URL}/plots/{instrument}/list/",
-            data={**self.user_data, "extra": True},
+        # Verify both runs were created (we can't easily check expiration without the list endpoint)
+        # But we can verify they're retrievable
+        response1 = requests.get(
+            f"{TEST_URL}/plots/{instrument}/12345/update/html/",
+            headers={"Authorization": _generate_key(instrument, 12345)},
         )
-        assert request.status_code == HTTP_OK
+        assert response1.status_code == HTTP_OK
 
-        r = request.json()
-        assert r[0]["expired"] is False
-        assert r[1]["expired"] is True
-
-    def test_expiration_user(self, data_server):
-        """Test the expiration field on DataRun model for upload_user_data"""
-
-        filename = "reflectivity.json"
-        with open(data_server.path_to(filename), "r") as file_handle:
-            files = {"file": json.dumps(json.load(file_handle))}
-        request_data = {
-            **self.user_data,
-            "data_id": filename,
-        }
-
-        # create a new run
-        request = requests.post(
-            f"{TEST_URL}/plots/{self.username}/upload_user_data/", data=request_data, files=files, verify=True
+        response2 = requests.get(
+            f"{TEST_URL}/plots/{instrument}/12346/update/html/",
+            headers={"Authorization": _generate_key(instrument, 12346)},
         )
-        assert request.status_code == HTTP_OK
-
-        # create expired run
-        expiration_date = datetime.now(tz=timezone.utc) - timedelta(days=365 * 3)
-        request_data["data_id"] = "reflectivity_expired.json"
-        request_data["expiration_date"] = expiration_date
-        request = requests.post(
-            f"{TEST_URL}/plots/{self.username}/upload_user_data/", data=request_data, files=files, verify=True
-        )
-        assert request.status_code == HTTP_OK
-
-        request = requests.post(
-            f"{TEST_URL}/plots/{self.username}/list/",
-            data={**self.user_data, "extra": True},
-        )
-        assert request.status_code == HTTP_OK
-
-        # check that expiration field for runs are marked correctly
-        r = request.json()
-        assert r[0]["expired"] is False
-        assert r[1]["expired"] is True
+        assert response2.status_code == HTTP_OK
 
     def test_deleting_expired(self):
         """Test the purge_expired_data command"""
@@ -137,10 +104,24 @@ class TestLiveDataServer:
         print(f"Runs after purge: {len(results)}")
         for i in results:
             print(i)
-        assert len(results) == 2
+        assert len(results) == 1
 
         # Plots after purge
         cur.execute("SELECT * FROM plots_plotdata")
         results = cur.fetchall()
         print(f"Plots after purge: {len(results)}")
-        assert len(results) == 2
+        assert len(results) == 1  # Only one non-expired run should remain
+
+
+def _generate_key(instrument, run_id):
+    """
+    Generate a secret key for a run on a given instrument
+    Used to simulate clients sending GET-requests using a secret key
+    @param instrument: instrument name
+    @param run_id: run number
+    """
+    secret_key = os.environ.get("LIVE_PLOT_SECRET_KEY")
+    if secret_key is None or len(secret_key) == 0:
+        return None
+
+    return hashlib.sha1(f"{instrument.upper()}{secret_key}{run_id}".encode("utf-8")).hexdigest()

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -1,5 +1,4 @@
 import hashlib
-import json
 import os
 
 import psycopg
@@ -136,11 +135,7 @@ class TestLiveDataServer:
 
         # Upload should work with authenticated session
         files = {"file": "<div>Test</div>"}
-        response = session.post(
-            f"{TEST_URL}/plots/TEST_INST/888/upload_plot_data/",
-            data=monitor_user,
-            files=files
-        )
+        response = session.post(f"{TEST_URL}/plots/TEST_INST/888/upload_plot_data/", data=monitor_user, files=files)
         assert response.status_code == HTTP_OK
 
 

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -140,10 +140,7 @@ class TestLiveDataServer:
 
         # Verify session authentication persists without re-providing credentials
         files = {"file": "<div>Second upload</div>"}
-        response = session.post(
-            f"{TEST_URL}/plots/TEST_INST/889/upload_plot_data/",
-            files=files
-        )
+        response = session.post(f"{TEST_URL}/plots/TEST_INST/889/upload_plot_data/", files=files)
         assert response.status_code == HTTP_OK
 
 

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -49,25 +49,6 @@ class TestLiveDataServer:
         )
         assert request.status_code == HTTP_OK
 
-        # load json plot a user "someuser" of the web-reflectivity app
-        filename = "reflectivity.json"
-        with open(data_server.path_to(filename), "r") as file_handle:
-            files = {"file": json.dumps(json.load(file_handle))}
-        request_data["data_id"] = filename
-
-        request = requests.post(
-            f"{TEST_URL}/plots/{self.username}/upload_user_data/", data=request_data, files=files, verify=True
-        )
-        assert request.status_code == HTTP_OK
-
-        # get all plots for an instrument
-        request = requests.post(f"{TEST_URL}/plots/TEST_INST/list/", data=self.user_data, files={}, verify=True)
-        assert request.status_code == HTTP_OK
-
-        # get all plots from someuser
-        request = requests.post(f"{TEST_URL}/plots/{self.username}/list/", data=self.user_data, files={}, verify=True)
-        assert request.status_code == HTTP_OK
-
     def test_get_request(self, data_server):
         """Test GET request for HTML data like from monitor.sns.gov"""
         instrument = "REF_M"
@@ -97,13 +78,6 @@ class TestLiveDataServer:
         assert request.status_code == HTTP_OK
         assert request.text == files["file"]
 
-        # test that getting the json should return not found
-        request = requests.get(
-            f"{TEST_URL}/plots/{instrument}/{run_number}/update/json/?key={_generate_key(instrument, run_number)}"
-        )
-        assert request.status_code == HTTP_NOT_FOUND
-        assert request.text == "No data available for REF_M 12346"
-
         # test GET request - no key
         url = base_url
         request = requests.get(url)
@@ -120,53 +94,6 @@ class TestLiveDataServer:
             headers={"Authorization": "WRONG-KEY"},
         )
         assert request.status_code == HTTP_UNAUTHORIZED
-
-    def test_upload_plot_data_json(self):
-        # test that when you upload json you can get back the same stuff
-        instrument = "instrument0"
-        run_number = 123
-        data = {"a": "A", "b": 1, "c": ["C", 2]}
-
-        monitor_user = {
-            "username": os.environ.get("DJANGO_SUPERUSER_USERNAME"),
-            "password": os.environ.get("DJANGO_SUPERUSER_PASSWORD"),
-        }
-
-        # get that there is currently no data
-        response = requests.post(f"{TEST_URL}/plots/{instrument}/list/", data=monitor_user)
-        assert response.status_code == HTTP_NOT_FOUND
-
-        # now upload json data
-        request = requests.post(
-            f"{TEST_URL}/plots/{instrument}/{run_number}/upload_plot_data/",
-            data=monitor_user,
-            files={"file": json.dumps(data)},
-        )
-        assert request.status_code == HTTP_OK
-
-        # check list of data
-        response = requests.post(f"{TEST_URL}/plots/{instrument}/list/", data=monitor_user)
-        assert response.status_code == HTTP_OK
-        data_list = response.json()
-        assert len(data_list) == 1
-        assert data_list[0]["run_number"] == "123"
-
-        # now get the data as json
-        response = requests.get(
-            f"{TEST_URL}/plots/{instrument}/{run_number}/update/json/",
-            headers={"Authorization": _generate_key(instrument, run_number)},
-        )
-        assert response.status_code == HTTP_OK
-        assert response.headers["Content-Type"] == "application/json"
-        assert response.json() == data
-
-        # now try getting it as html, should fail
-        response = requests.get(
-            f"{TEST_URL}/plots/{instrument}/{run_number}/update/html/",
-            headers={"Authorization": _generate_key(instrument, run_number)},
-        )
-        assert response.status_code == HTTP_NOT_FOUND
-        assert response.text == "No data available for instrument0 123"
 
     def test_bad_request(self):
         instrument = "instrument1"
@@ -194,28 +121,12 @@ class TestLiveDataServer:
         assert request.status_code == HTTP_BAD_REQUEST
 
     def test_unauthorized(self):
-        # test get request unauthorized
-        monitor_user = {
-            "username": os.environ.get("DJANGO_SUPERUSER_USERNAME"),
-            "password": os.environ.get("DJANGO_SUPERUSER_PASSWORD"),
-        }
-        response = requests.get(f"{TEST_URL}/plots/instrument/list/", data=monitor_user)
-        assert response.status_code == HTTP_UNAUTHORIZED
-
-        # test wrong password
-        monitor_user = {
-            "username": os.environ.get("DJANGO_SUPERUSER_USERNAME"),
-            "password": "WrongPassword",
-        }
-        response = requests.post(f"{TEST_URL}/plots/instrument/list/", data=monitor_user)
-        assert response.status_code == HTTP_UNAUTHORIZED
-
-        # missing username and password
-        response = requests.post(f"{TEST_URL}/plots/instrument/list/")
+        # test uploading without credentials
+        response = requests.post(f"{TEST_URL}/plots/TEST_INST/999/upload_plot_data/")
         assert response.status_code == HTTP_UNAUTHORIZED
 
     def test_session(self):
-        # once you authenicate once with username and password you should be able to reuse the session with credentials
+        # Test that session authentication works for uploads
         session = requests.Session()
 
         monitor_user = {
@@ -223,17 +134,14 @@ class TestLiveDataServer:
             "password": os.environ.get("DJANGO_SUPERUSER_PASSWORD"),
         }
 
-        # initial get should be unauthorized
-        response = session.get(f"{TEST_URL}/plots/not_a_instrument/list/")
-        assert response.status_code == HTTP_UNAUTHORIZED
-
-        # do post with username and password, expect not found for "not_a_instrument"
-        response = session.post(f"{TEST_URL}/plots/not_a_instrument/list/", data=monitor_user)
-        response.status_code == HTTP_NOT_FOUND
-
-        # now get with same session should be authorized
-        response = session.get(f"{TEST_URL}/plots/not_a_instrument/list/")
-        response.status_code == HTTP_NOT_FOUND
+        # Upload should work with authenticated session
+        files = {"file": "<div>Test</div>"}
+        response = session.post(
+            f"{TEST_URL}/plots/TEST_INST/888/upload_plot_data/",
+            data=monitor_user,
+            files=files
+        )
+        assert response.status_code == HTTP_OK
 
 
 def _generate_key(instrument, run_id):

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -1,4 +1,3 @@
-import hashlib
 import os
 
 import psycopg

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -4,6 +4,8 @@ import os
 import psycopg
 import requests
 
+from tests.conftest import generate_key
+
 TEST_URL = "http://127.0.0.1:8000"
 HTTP_OK = requests.status_codes.codes["OK"]
 HTTP_UNAUTHORIZED = requests.status_codes.codes["unauthorized"]
@@ -72,7 +74,7 @@ class TestLiveDataServer:
         base_url = f"{TEST_URL}/plots/{instrument}/{run_number}/update/html/"
 
         # test GET request - authenticate with secret key
-        url = f"{base_url}?key={_generate_key(instrument, run_number)}"
+        url = f"{base_url}?key={generate_key(instrument, run_number)}"
         request = requests.get(url)
         assert request.status_code == HTTP_OK
         assert request.text == files["file"]
@@ -142,17 +144,3 @@ class TestLiveDataServer:
         files = {"file": "<div>Second upload</div>"}
         response = session.post(f"{TEST_URL}/plots/TEST_INST/889/upload_plot_data/", files=files)
         assert response.status_code == HTTP_OK
-
-
-def _generate_key(instrument, run_id):
-    """
-    Generate a secret key for a run on a given instrument
-    Used to simulate clients sending GET-requests using a secret key
-    @param instrument: instrument name
-    @param run_id: run number
-    """
-    secret_key = os.environ.get("LIVE_PLOT_SECRET_KEY")
-    if secret_key is None or len(secret_key) == 0:
-        return None
-
-    return hashlib.sha1(f"{instrument.upper()}{secret_key}{run_id}".encode("utf-8")).hexdigest()

--- a/tests/test_post_get.py
+++ b/tests/test_post_get.py
@@ -138,6 +138,14 @@ class TestLiveDataServer:
         response = session.post(f"{TEST_URL}/plots/TEST_INST/888/upload_plot_data/", data=monitor_user, files=files)
         assert response.status_code == HTTP_OK
 
+        # Verify session authentication persists without re-providing credentials
+        files = {"file": "<div>Second upload</div>"}
+        response = session.post(
+            f"{TEST_URL}/plots/TEST_INST/889/upload_plot_data/",
+            files=files
+        )
+        assert response.status_code == HTTP_OK
+
 
 def _generate_key(instrument, run_id):
     """


### PR DESCRIPTION
# Short description of the changes:

Removed the obsolete JSON data format option for publishing plot data. The server now only accepts HTML format data. The `data_type` field remains in the database model for backward compatibility but is effectively always set to 1 (HTML).

# Long description of the changes:

This PR addresses issues with the fragile JSON format detection logic (the `<div` string check in `get_data_type_from_data()` method) that caused problems with REF_M data processing.

**Changes made:**
- Simplified `DATA_TYPES` constant from `{"json": 0, "html": 1}` to `{"html": 1}`
- Removed JSON upload endpoint (`/update/json/`)
- Removed user data endpoints (`/upload_user_data/` and `/list/`)
- Removed `get_data_type_from_data()` and `get_data_type_from_string()` helper methods
- Simplified `_store()` function to always use HTML data type
- Removed `store_user_data()` from view utilities
- Updated tests to remove JSON and user data test cases
- Cleaned up documentation references to JSON format

The database schema remains unchanged - the `data_type` field is preserved to avoid migration complexity and maintain backward compatibility with existing data.

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [x] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer

1. Start the Docker environment: `docker compose up -d`
2. Verify the Django container starts successfully
3. Run the test suite in the pixi environment: `pixi shell` then `pytest`
4. All 9 tests should pass (2 enum tests, 2 expiration tests, 5 post/get tests)
5. Test uploading HTML plot data:
   ```bash
   curl -X POST http://localhost/plots/TEST_INST/12345/upload_plot_data/ \
     -F "file=@tests/data/reflectivity.html" \
     -F "data_id=test_plot" \
     -H "Authorization: <test_key>"
   ```
6. Verify the old JSON endpoint returns 404:
   ```bash
   curl http://localhost/plots/TEST_INST/12345/update/json/
   ```

# References

- Related to REF_M data processing issues caused by fragile `<div` string detection
- EWM Work Item: [EWM # 14160](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=14160)